### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Austincitylimits/Form/Settings.php
+++ b/CRM/Austincitylimits/Form/Settings.php
@@ -40,7 +40,7 @@ class CRM_Austincitylimits_Form_Settings extends CRM_Core_Form {
         'options' => array('limit' => ""),
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error %1', array(
         'domain' => 'com.aghstrategies.austincitylimits',

--- a/CRM/Austincitylimits/Geo.php
+++ b/CRM/Austincitylimits/Geo.php
@@ -80,7 +80,7 @@ class CRM_Austincitylimits_Geo {
         'id' => $contactId,
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error: %1', array(
         'domain' => 'com.aghstrategies.austincitylimits',
@@ -103,7 +103,7 @@ class CRM_Austincitylimits_Geo {
         'id' => $contactId,
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error: %1', array(
         'domain' => 'com.aghstrategies.austincitylimits',

--- a/api/v3/Austincitylimits/Citycouncildistrict.php
+++ b/api/v3/Austincitylimits/Citycouncildistrict.php
@@ -20,7 +20,7 @@ function _civicrm_api3_austincitylimits_Citycouncildistrict_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_austincitylimits_Citycouncildistrict($params) {
   $params = array(
@@ -38,9 +38,9 @@ function civicrm_api3_austincitylimits_Citycouncildistrict($params) {
   try {
     $addresses = civicrm_api3('Contact', 'get', $params);
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     $error = $e->getMessage();
-    throw new API_Exception(/*errorMessage*/ ts('Cannot find any contacts with a primary home addresse in Texas with an empty city council district', array('domain' => 'com.aghstrategies.austincitylimits')), /*errorCode*/ 10);
+    throw new CRM_Core_Exception(/*errorMessage*/ ts('Cannot find any contacts with a primary home addresse in Texas with an empty city council district', array('domain' => 'com.aghstrategies.austincitylimits')), /*errorCode*/ 10);
   }
   foreach ($addresses['values'] as $address) {
     $geo = new CRM_Austincitylimits_Geo($address['geo_code_1'], $address['geo_code_2']);

--- a/austincitylimits.php
+++ b/austincitylimits.php
@@ -29,7 +29,7 @@ function austincitylimits_civicrm_post($op, $objectName, $objectId, &$objectRef)
               $contacts[] = $value['contact_id'];
             }
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             $error = $e->getMessage();
             CRM_Core_Error::debug_log_message(ts('API Error %1', array(
               'domain' => 'com.aghstrategies.austincitylimits',
@@ -118,7 +118,7 @@ function austincitylimits_civicrm_validateForm($formName, &$fields, &$files, &$f
           'location_type_id' => "Home",
         ));
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message(ts('API Error %1', array(
           'domain' => 'com.aghstrategies.austincitylimits',


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.